### PR TITLE
Bugfix/#22435 sslcheck invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,24 @@
 # redborder-repo
 
-Build a particular product version:
+Este repositorio permite construir paquetes RPM de un producto específico de Redborder.
+
+## Construir una versión específica del producto
+Para compilar un RPM de una versión concreta del producto:
 
 ```
 PRODUCT_VERSION=25.04 VERSION=0.0.1 make rpm
 ```
 
-Build latest (by default PRODUCT_VERSION=latest):
+## Construir la última versión disponible
+Si no se especifica **PRODUCT_VERSION**, por defecto se usará `latest`:
 
-```
+```bash
 VERSION=0.0.1 make rpm
 ```
 
-Build with different URL:
-```
-VERSION=0.0.1 REPO_URL="https://packages.redborder.com" make rpm
+## Construir desde una URL distinta
+Para usar un repositorio personalizado, por defecto se usará `https://packages.redborder.com`:
+
+```bash
+VERSION=0.0.1 REPO_URL="https://packages.redbordersc.lan" make rpm
 ```

--- a/packaging/rpm/redborder-repo.spec
+++ b/packaging/rpm/redborder-repo.spec
@@ -38,7 +38,7 @@ rm -rf $RPM_BUILD_ROOT
 %changelog
 * Fri Sep 22 2023 Miguel Negrón <manegron@redborder.com> - 1.0.0-1
 - Move to rhel9
-* Wed Jan 27 2020 Juan J. Prieto <jjprieto@redborder.com> - 0.0.5-1
+* Mon Jan 27 2020 Juan J. Prieto <jjprieto@redborder.com> - 0.0.5-1
 - Replace logstash 6 repo by 7
 * Thu Jan 24 2018 Juan J. Prieto <jjprieto@redborder.com> - 0.0.4-1
 - Add logstash repo

--- a/packaging/rpm/redborder-repo.spec
+++ b/packaging/rpm/redborder-repo.spec
@@ -36,7 +36,7 @@ rm -rf $RPM_BUILD_ROOT
 /etc/pki/rpm-gpg/RPM-GPG-KEY-redborder-repo
 
 %changelog
-* Frid Sep 22 2023 Miguel Negrón <manegron@redborder.com> - 1.0.0-1
+* Fri Sep 22 2023 Miguel Negrón <manegron@redborder.com> - 1.0.0-1
 - Move to rhel9
 * Wed Jan 27 2020 Juan J. Prieto <jjprieto@redborder.com> - 0.0.5-1
 - Replace logstash 6 repo by 7
@@ -48,4 +48,3 @@ rm -rf $RPM_BUILD_ROOT
 - Add gpg public key
 * Fri Oct 28 2016 Juan J. Prieto <jjprieto@redborder.com> - 0.0.1-1
 - first spec version
-

--- a/resources/redborder.repo
+++ b/resources/redborder.repo
@@ -3,6 +3,6 @@ name=Redborder Official Repository - $basearch
 baseurl={{REPO_URL}}/{{PRODUCT_VERSION}}/rhel/9/$basearch/
 enabled=1
 gpgcheck=0
-sslcheck=0
+sslverify=0
 metadata_expire=6h
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redborder-repo


### PR DESCRIPTION
We fix sslcheck argument for redborder-repo.
Devel repos are not included because we don't use this repository for that.